### PR TITLE
Attempt a checkout before pulling remote

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -63,23 +63,22 @@ func (i *Import) RestoreImport(gopath string) error {
 		return err
 	}
 
-	// Download changes
+	// Attempt to checkout revision.
+	cmdString := i.Repo.VCS.TagSyncCmd
+	cmdString = strings.Replace(cmdString, "{tag}", i.Rev, 1)
+	if _, err = runInDir(i.Repo.VCS.Cmd, strings.Fields(cmdString), fullpath, i.Verbose); err == nil {
+		return nil
+	}
+
+	// There was an error checking out revision: download changes and
+	// re-checkout revision
 	err = i.Repo.VCS.Download(fullpath)
 	if err != nil {
 		return fmt.Errorf("Error downloading changes to %s, %s\n",
 			fullpath, err.Error())
 	}
-
-	// Checkout revision
-	cmdString := i.Repo.VCS.TagSyncCmd
-	cmdString = strings.Replace(cmdString, "{tag}", i.Rev, 1)
-	_, err = runInDir(i.Repo.VCS.Cmd, strings.Fields(cmdString),
-		fullpath, i.Verbose)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err = runInDir(i.Repo.VCS.Cmd, strings.Fields(cmdString), fullpath, i.Verbose)
+	return err
 }
 
 // ImportsFromFile reads the given file and returns Import structs.


### PR DESCRIPTION
Rather than attempting to fetch the dependency remotely and then
checking out the revision, the opposite will now happen.

First, `gdm` will attempt to checkout the correct revision, and on error
the latest changes of the dependency will be fetched, and the checkout
re-attempted.

This has two advantages:
1. It allows us to make a private dependency available to `gdm` without
    `gdm` attempting to fetch it.
2. It's more efficient in the common case that the working tree has
    the dependency available locally with the desired revision.
